### PR TITLE
ci: Add path triggers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'ci/only-build-on-relevant-changes'
     tags:
       - 'v*'
     paths:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'ci/only-build-on-relevant-changes'
     tags:
       - 'v*'
     paths:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,11 @@ on:
       - main
     tags:
       - 'v*'
+    paths:
+      - 'examples/hello_pytorch/pixi.toml'
+      - 'examples/hello_pytorch/pixi.lock'
+      - 'examples/hello_pytorch/Dockerfile'
+      - 'examples/hello_pytorch/.dockerignore'
   pull_request:
   release:
     types: [published]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,14 @@ on:
       - 'examples/hello_pytorch/pixi.lock'
       - 'examples/hello_pytorch/Dockerfile'
       - 'examples/hello_pytorch/.dockerignore'
+      - 'examples/hello_pytorch/src/**'
   pull_request:
+    paths:
+      - 'examples/hello_pytorch/pixi.toml'
+      - 'examples/hello_pytorch/pixi.lock'
+      - 'examples/hello_pytorch/Dockerfile'
+      - 'examples/hello_pytorch/.dockerignore'
+      - 'examples/hello_pytorch/src/**'
   release:
     types: [published]
   workflow_dispatch:

--- a/examples/hello_pytorch/Dockerfile
+++ b/examples/hello_pytorch/Dockerfile
@@ -10,7 +10,6 @@ RUN echo "#!/bin/bash" > /app/entrypoint.sh && \
 
 FROM ghcr.io/prefix-dev/pixi:noble AS production
 
-# ECHO REVERT
 WORKDIR /app
 COPY --from=build /app/.pixi/envs/prod /app/.pixi/envs/prod
 COPY --from=build /app/pixi.toml /app/pixi.toml

--- a/examples/hello_pytorch/Dockerfile
+++ b/examples/hello_pytorch/Dockerfile
@@ -10,6 +10,7 @@ RUN echo "#!/bin/bash" > /app/entrypoint.sh && \
 
 FROM ghcr.io/prefix-dev/pixi:noble AS production
 
+# ECHO REVERT
 WORKDIR /app
 COPY --from=build /app/.pixi/envs/prod /app/.pixi/envs/prod
 COPY --from=build /app/pixi.toml /app/pixi.toml


### PR DESCRIPTION
* Add path triggers to only build the Docker images when there are changes to the Pixi environment files or the Docker or source files.
   - c.f. https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore