### PR TITLE
chore: Update image tags to reflect cuda 12.9 use

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,7 @@ jobs:
             ghcr.io/uw-madison-dsi/pixi-docker-chtc
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=raw,value=hello-pytorch-noble-cuda-12.6.3
+            type=raw,value=hello-pytorch-noble-cuda-12.9
             type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/examples/hello_pytorch/README.md
+++ b/examples/hello_pytorch/README.md
@@ -35,7 +35,7 @@ bash build.sh
 > ```
 
 ```
-docker run --rm -ti --gpus all ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.6.3 bash
+docker run --rm -ti --gpus all ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 bash
 ```
 
 ```console
@@ -63,11 +63,11 @@ root@5789c0254776:/app#
 or use the `pixi` tasks
 
 ```
-docker run --rm --gpus all ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.6.3 pixi run train-mnist
+docker run --rm --gpus all ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 pixi run train-mnist
 ```
 
 or the explicit commands
 
 ```
-docker run --rm --gpus all ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.6.3 python ./src/torch_MNIST.py
+docker run --rm --gpus all ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 python ./src/torch_MNIST.py
 ```

--- a/examples/hello_pytorch/build.sh
+++ b/examples/hello_pytorch/build.sh
@@ -4,12 +4,12 @@ docker system prune -f
 
 docker pull tonistiigi/binfmt
 docker pull ghcr.io/prefix-dev/pixi:noble
-docker pull ghcr.io/prefix-dev/pixi:noble-cuda-12.6.3
+docker pull ghcr.io/prefix-dev/pixi:noble-cuda-12.9
 
 docker build \
     --file Dockerfile \
     --platform linux/amd64 \
-    --tag ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.6.3 \
+    --tag ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 \
     .
 
 docker images ghcr.io/uw-madison-dsi/pixi-docker-chtc

--- a/examples/hello_pytorch/htcondor/README.md
+++ b/examples/hello_pytorch/htcondor/README.md
@@ -32,7 +32,7 @@ where the reasoning for the options is:
 ### Example using the example's container image
 
 ```
-docker run --rm -ti --gpus all --user 12345 -v $(pwd):/scratch -w /scratch ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.6.3 bash
+docker run --rm -ti --gpus all --user 12345 -v $(pwd):/scratch -w /scratch ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 bash
 ```
 
 ## Running

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
@@ -5,7 +5,7 @@
 universe = docker
 # To avoid excessive pulls, and potential rate limits, set as "missing" (default value) unless "always" needed for updated tag
 docker_pull_policy = missing
-docker_image = ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.6.3
+docker_image = ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9
 
 # set the log, error and output files
 log = hello_pytorch_gpu.log.txt


### PR DESCRIPTION
* cuda 12.9.* is used in the Pixi environment, so to convey a useful level of detail in the Docker image tag, use cuda-12.9 in the label.