### PR TITLE
ci: Set permissions for job explicitly

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,10 +27,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   docker:
     name: Build and publish images
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
* Remove all permissions from GitHub Action use by setting permissions for the workflow to the empty set '{}'.
* Add permissions for content read and package (registry) write to the 'docker' job.