### PR TITLE
feat: Transfer runtime code at submit and use container universe

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,7 +55,7 @@ jobs:
             type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            # type=sha
+            type=sha
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/examples/hello_pytorch/Dockerfile
+++ b/examples/hello_pytorch/Dockerfile
@@ -14,10 +14,14 @@ WORKDIR /app
 COPY --from=build /app/.pixi/envs/prod /app/.pixi/envs/prod
 COPY --from=build /app/pixi.toml /app/pixi.toml
 COPY --from=build /app/pixi.lock /app/pixi.lock
-# Need the .gitignore if you want to use `pixi run` commands
+# Need the ignore files if you want to use `pixi run` commands
 COPY --from=build /app/.gitignore /app/.pixi/.gitignore
+COPY --from=build /app/.pixi/.condapackageignore /app/.pixi/.condapackageignore
 COPY --from=build --chmod=0755 /app/entrypoint.sh /app/entrypoint.sh
-COPY ./src /app/src
+
+# Copy only application config or utility files
+# Runtime code should be transfer over during the job
+COPY ./src/torch_detect_GPU.py /app/src/torch_detect_GPU.py
 
 EXPOSE 8000
 ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sh
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sh
@@ -28,7 +28,10 @@ else
     exit 1
 fi
 
+echo -e "\n# Check that the training code exists:\n"
+ls -1ap ./src/
+
 echo -e "\n# Train MNIST with PyTorch:\n"
 mkdir -p run
 cd run
-time python /app/src/torch_MNIST.py --epochs 14 --save-model
+time python ../src/torch_MNIST.py --epochs 14 --save-model

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
@@ -1,11 +1,11 @@
 # hello_pytorch_gpu.sub
 # Submit file to access the GPU via docker
 
-# Must set the universe to Docker
-universe = docker
+# Must set the universe to 'container' to use Docker
+universe = container
 # To avoid excessive pulls, and potential rate limits, set as "missing" (default value) unless "always" needed for updated tag
 docker_pull_policy = missing
-docker_image = ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9
+container_image = docker://ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9
 
 # set the log, error and output files
 log = hello_pytorch_gpu.log.txt
@@ -16,8 +16,8 @@ output = hello_pytorch_gpu.out.txt
 executable = hello_pytorch_gpu.sh
 arguments = $(Process)
 
-# transfer training data files to the compute node
-transfer_input_files = MNIST_data.tar.gz
+# transfer training data files and runtime source files to the compute node
+transfer_input_files = MNIST_data.tar.gz,../src
 
 # transfer the serialized trained model back
 transfer_output_files = run/mnist_cnn.pt


### PR DESCRIPTION
* Copy only application config files or utility files into the Docker container build and transfer all runtime source files at the job submission time.
    - This is to allow for more rapid development where the source code may change but the computational software environment does not and so avoids rebuilds.
* Use the 'container' universe for Docker container jobs, but still keep the docker_pull_policy as

> It'll be used on Execution Points that use Docker and ignored on Execution Points that use Singularity/Apptainer. HTCondor does not provide its own cache management for container images. It can transfer a SIF file or exploded SIF directory from the Access Point on request. &mdash; @JaimeFrey 

   - c.f. https://htcondor.readthedocs.io/en/latest/users-manual/env-of-job.html#container-universe-jobs

* Tag Docker container images with the commit sha when they're built.