### PR TITLE
feat: Add data-dir argument to PyTorch MNIST code

### DIFF
--- a/examples/hello_pytorch/README.md
+++ b/examples/hello_pytorch/README.md
@@ -35,7 +35,7 @@ bash build.sh
 > ```
 
 ```
-docker run --rm -ti --gpus all ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 bash
+docker run --rm -ti --gpus all -v $PWD:/app -w /app ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 bash
 ```
 
 ```console
@@ -63,11 +63,11 @@ root@5789c0254776:/app#
 or use the `pixi` tasks
 
 ```
-docker run --rm --gpus all ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 pixi run train-mnist
+docker run --rm --gpus all -v $PWD:/app -w /app ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 pixi run train-mnist
 ```
 
 or the explicit commands
 
 ```
-docker run --rm --gpus all ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 python ./src/torch_MNIST.py
+docker run --rm --gpus all -v $PWD:/app -w /app ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 python ./src/torch_MNIST.py
 ```

--- a/examples/hello_pytorch/README.md
+++ b/examples/hello_pytorch/README.md
@@ -35,7 +35,7 @@ bash build.sh
 > ```
 
 ```
-docker run --rm -ti --gpus all -v $PWD:/app -w /app ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 bash
+docker run --rm -ti --gpus all -v $PWD:/run ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 bash
 ```
 
 ```console
@@ -48,7 +48,7 @@ Number of GPUs found on system: 1
 
 Active GPU index: 0
 Active GPU name: NVIDIA GeForce RTX 4060 Laptop GPU
-root@5789c0254776:/app# python ./src/torch_MNIST.py
+root@5789c0254776:/app# python /run/src/torch_MNIST.py
 ...
 Train Epoch: 14 [57600/60000 (96%)]	Loss: 0.001337
 Train Epoch: 14 [58240/60000 (97%)]	Loss: 0.009490
@@ -63,11 +63,11 @@ root@5789c0254776:/app#
 or use the `pixi` tasks
 
 ```
-docker run --rm --gpus all -v $PWD:/app -w /app ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 pixi run train-mnist
+docker run --rm --gpus all -v $PWD:/run -w /run ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 pixi run train-mnist
 ```
 
 or the explicit commands
 
 ```
-docker run --rm --gpus all -v $PWD:/app -w /app ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 python ./src/torch_MNIST.py
+docker run --rm --gpus all -v $PWD:/run -w /run ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9 python ./src/torch_MNIST.py
 ```

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sh
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sh
@@ -37,6 +37,4 @@ echo -e "\n# Check that the training code exists:\n"
 ls -1ap ./src/
 
 echo -e "\n# Train MNIST with PyTorch:\n"
-mkdir -p run
-cd run
-time python ../src/torch_MNIST.py --epochs 14 --save-model
+time python ./src/torch_MNIST.py --epochs 14 --data-dir ./data --save-model

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
@@ -17,7 +17,7 @@ arguments = $(Process)
 transfer_input_files = MNIST_data.tar.gz,../../src
 
 # transfer the serialized trained model back
-transfer_output_files = run/mnist_cnn.pt
+transfer_output_files = mnist_cnn.pt
 
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sh
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sh
@@ -32,6 +32,4 @@ echo -e "\n# Check that the training code exists:\n"
 ls -1ap ./src/
 
 echo -e "\n# Train MNIST with PyTorch:\n"
-mkdir -p run
-cd run
-time python ../src/torch_MNIST.py --epochs 14 --save-model
+time python ./src/torch_MNIST.py --epochs 14 --data-dir ./data --save-model

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
@@ -20,7 +20,7 @@ arguments = $(Process)
 transfer_input_files = MNIST_data.tar.gz,../src
 
 # transfer the serialized trained model back
-transfer_output_files = run/mnist_cnn.pt
+transfer_output_files = mnist_cnn.pt
 
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT

--- a/examples/hello_pytorch/htcondor/pixi-pack/hello_pytorch_gpu_pixi-pack.sh
+++ b/examples/hello_pytorch/htcondor/pixi-pack/hello_pytorch_gpu_pixi-pack.sh
@@ -29,6 +29,4 @@ else
 fi
 
 echo -e "\n# Train MNIST with PyTorch:\n"
-mkdir -p run
-cd run
-time python ../torch_MNIST.py --epochs 14 --save-model
+time python ./src/torch_MNIST.py --epochs 14 --data-dir ./data --save-model

--- a/examples/hello_pytorch/htcondor/pixi-pack/hello_pytorch_gpu_pixi-pack.sub
+++ b/examples/hello_pytorch/htcondor/pixi-pack/hello_pytorch_gpu_pixi-pack.sub
@@ -14,7 +14,7 @@ arguments = $(Process)
 transfer_input_files = osdf:///chtc/staging/mfeickert/envs/hello_pytorch/hello-pytorch-environment-b8dd14a4.sh, MNIST_data.tar.gz, ../../src/torch_detect_GPU.py, ../../src/torch_MNIST.py
 
 # transfer the serialized trained model back
-transfer_output_files = run/mnist_cnn.pt
+transfer_output_files = mnist_cnn.pt
 
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT

--- a/examples/hello_pytorch/src/torch_MNIST.py
+++ b/examples/hello_pytorch/src/torch_MNIST.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 import torch.optim as optim
 from torchvision import datasets, transforms
 from torch.optim.lr_scheduler import StepLR
+from pathlib import Path
 
 
 class Net(nn.Module):
@@ -149,7 +150,13 @@ def main():
         default=False,
         help="For Saving the current Model",
     )
+    parser.add_argument(
+        "--data-dir",
+        default=Path.cwd() / "data",
+        help="Path to the directory with the MNIST training data (default: current directory/data)",
+    )
     args = parser.parse_args()
+    args.data_dir = Path(args.data_dir).resolve()
     use_cuda = not args.no_cuda and (
         torch.cuda.is_available() or torch.backends.mps.is_available()
     )
@@ -173,8 +180,10 @@ def main():
     transform = transforms.Compose(
         [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
     )
-    dataset1 = datasets.MNIST("../data", train=True, download=True, transform=transform)
-    dataset2 = datasets.MNIST("../data", train=False, transform=transform)
+    dataset1 = datasets.MNIST(
+        args.data_dir, train=True, download=True, transform=transform
+    )
+    dataset2 = datasets.MNIST(args.data_dir, train=False, transform=transform)
     train_loader = torch.utils.data.DataLoader(dataset1, **train_kwargs)
     test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)
 


### PR DESCRIPTION
* Allow the PyTorch MNIST example to be able to select the path to the data directory, and have it default to the `cwd / data`.
   - c.f. https://github.com/matthewfeickert/nvidia-gpu-ml-library-test/pull/22
* Remove creation of a `run` directory in the job execution script as the path to the data can now be set directly.