### PR TITLE
chore: Use commit SHA to tag Apptainer container SIF file

### DIFF
--- a/examples/hello_pytorch/build_apptainer.sh
+++ b/examples/hello_pytorch/build_apptainer.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-apptainer build pixi-docker-chtc.sif apptainer.def
+_sha=$(git rev-parse --verify --short HEAD)
+apptainer build pixi-docker-chtc-sha-"${_sha}".sif apptainer.def
 
-# apptainer run --nv --containall pixi-docker-chtc.sif bash
+# apptainer run --nv --containall pixi-docker-chtc*.sif bash
 
 # Note: The %runscript in the definition file is used to pass commands into the environment
-# apptainer run --nv --containall pixi-docker-chtc.sif python /app/src/torch_detect_GPU.py
+# apptainer run --nv --containall pixi-docker-chtc*.sif python /app/src/torch_detect_GPU.py
 
 # Note: 'apptainer exec' ignores the %runscript and the %startscript from the definition file
-# apptainer exec --nv --containall pixi-docker-chtc.sif /app/entrypoint.sh python /app/src/torch_detect_GPU.py
+# apptainer exec --nv --containall pixi-docker-chtc*.sif /app/entrypoint.sh python /app/src/torch_detect_GPU.py

--- a/examples/hello_pytorch/htcondor/apptainer/README.md
+++ b/examples/hello_pytorch/htcondor/apptainer/README.md
@@ -78,15 +78,15 @@ HTCondor submission syntax.
 **Example**:
 
 ```
-container_image = osdf:///chtc/staging/mfeickert/apptainer/pixi-docker-chtc-54990e82.sif
+container_image = osdf:///chtc/staging/mfeickert/apptainer/pixi-docker-chtc-sha-80ec247.sif
 ```
 
 OSDF offers the advantage of [not limiting your jobs to running on locations where `/staging/` is mounted](https://chtc.cs.wisc.edu/uw-research-computing/scaling-htc#3-submitting-jobs-to-run-beyond-chtc).
 
 > [!WARNING]
-> OSDF and Pelican treat all cached files as immutable, so each file placed on `/staging/` should have a unique name, such as including information about the file's hash in the file name
+> OSDF and Pelican treat all cached files as immutable, so each file placed on `/staging/` should have a unique name, such as including information about the repository's Git commit SHA in the file name
 > ```
-> mv pixi-docker-chtc.sif pixi-docker-chtc-"$(openssl sha256 -r pixi-docker-chtc.sif | cut -b -8)".sif
+> mv pixi-docker-chtc.sif pixi-docker-chtc-sha-"$(git rev-parse --verify --short HEAD)".sif
 > ```
 
 ### Advantages


### PR DESCRIPTION
* Use the commit SHA to tag the Apptainer container .sif file during build to have a more consistent tag system.