### PR TITLE
feat: Harmonize HTCondor submit description file between CHTC and OSPool

### DIFF
--- a/examples/hello_pytorch/htcondor/README.md
+++ b/examples/hello_pytorch/htcondor/README.md
@@ -130,3 +130,5 @@ CHTC's documentation has good resources on how to effectively use GPU resources 
 * [Use GPUS](https://chtc.cs.wisc.edu/uw-research-computing/gpu-jobs)
 * [Explore and Test Docker Containers](https://chtc.cs.wisc.edu/uw-research-computing/docker-test.html)
 * [Use an Apptainer Container in HTC Jobs](https://chtc.cs.wisc.edu/uw-research-computing/apptainer-htc#use-an-apptainer-container-in-htc-jobs)
+* [HTCondor Documentation "Commands for Matchmaking" section with GPU specific arguments](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#gpus_minimum_memory)
+* [Modal's GPU Glossary section on 'Compute Capability'](https://modal.com/gpu-glossary/device-software/compute-capability#gpu-glossary)

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
@@ -36,7 +36,7 @@ request_gpus = 1
 
 # select some memory and disk space
 request_memory = 2GB
-request_disk = 6GB
+request_disk = 2GB
 
 # Optional: specify the GPU hardware architecture required
 # Check against the CUDA GPU Compute Capability for your software

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
@@ -44,8 +44,8 @@ request_gpus = 1
 request_memory = 2GB
 request_disk = 6GB
 
-# required memory in MB (x000 is xGB)
-# gpus_minimum_memory = 6000
+# Optional: required GPU memory
+# gpus_minimum_memory = 4GB
 
 # Opt in to using CHTC GPU Lab resources
 +WantGPULab = true

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
@@ -34,7 +34,7 @@ requirements = (OpSysMajorVer > 7)
 # Check against the CUDA GPU Compute Capability for your software
 # e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
 # The listed 'sm_xy' values show the x.y gpu capability supported
-gpus_minimum_capability = 6.0
+gpus_minimum_capability = 5.0
 
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
@@ -36,7 +36,7 @@ request_gpus = 1
 
 # select some memory and disk space
 request_memory = 2GB
-request_disk = 2GB
+request_disk = 6GB
 
 # Optional: specify the GPU hardware architecture required
 # Check against the CUDA GPU Compute Capability for your software

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
@@ -36,7 +36,8 @@ request_gpus = 1
 
 # select some memory and disk space
 request_memory = 2GB
-request_disk = 6GB
+# Apptainer jobs take more disk than Docker jobs for some reason
+request_disk = 7GB
 
 # Optional: specify the GPU hardware architecture required
 # Check against the CUDA GPU Compute Capability for your software

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
@@ -29,7 +29,9 @@ when_to_transfer_output = ON_EXIT
 # requirements = (HasCHTCStaging == true)
 # Don't use CentOS7 to ensure pty support
 requirements = (OpSysMajorVer > 7)
-gpus_minimum_capability = 7.5
+# Check against the CUDA GPU Compute Capability for your software
+# e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
+gpus_minimum_capability = 6.0
 
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
@@ -29,8 +29,11 @@ when_to_transfer_output = ON_EXIT
 # requirements = (HasCHTCStaging == true)
 # Don't use CentOS7 to ensure pty support
 requirements = (OpSysMajorVer > 7)
+
+# Optional: specify the GPU hardware architecture required
 # Check against the CUDA GPU Compute Capability for your software
 # e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
+# The listed 'sm_xy' values show the x.y gpu capability supported
 gpus_minimum_capability = 6.0
 
 # We must request 1 CPU in addition to 1 GPU

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
@@ -5,9 +5,9 @@ universe = container
 container_image = oras://ghcr.io/uw-madison-dsi/pixi-docker-chtc:apptainer-hello-pytorch-noble-cuda-12.9
 
 # set the log, error and output files
-log = hello_pytorch_gpu_apptainer.log.txt
-error = hello_pytorch_gpu_apptainer.err.txt
-output = hello_pytorch_gpu_apptainer.out.txt
+log = hello_pytorch_gpu_apptainer_$(Cluster)_$(Process).log.txt
+error = hello_pytorch_gpu_apptainer_$(Cluster)_$(Process).err.txt
+output = hello_pytorch_gpu_apptainer_$(Cluster)_$(Process).out.txt
 
 # set the executable to run
 executable = hello_pytorch_gpu_apptainer.sh
@@ -24,17 +24,11 @@ transfer_output_files = mnist_cnn.pt
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 
-# We require a machine with a modern version of the CUDA driver
-# requirements = (Target.CUDADriverVersion >= 12.0)
-# requirements = (HasCHTCStaging == true)
+# Require a machine with a modern version of the CUDA driver
+requirements = (GPUs_DriverVersion >= 12.0)
+
 # Don't use CentOS7 to ensure pty support
 requirements = (OpSysMajorVer > 7)
-
-# Optional: specify the GPU hardware architecture required
-# Check against the CUDA GPU Compute Capability for your software
-# e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
-# The listed 'sm_xy' values show the x.y gpu capability supported
-gpus_minimum_capability = 5.0
 
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1
@@ -43,6 +37,12 @@ request_gpus = 1
 # select some memory and disk space
 request_memory = 2GB
 request_disk = 6GB
+
+# Optional: specify the GPU hardware architecture required
+# Check against the CUDA GPU Compute Capability for your software
+# e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
+# The listed 'sm_xy' values show the x.y gpu capability supported
+gpus_minimum_capability = 5.0
 
 # Optional: required GPU memory
 # gpus_minimum_memory = 4GB

--- a/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
+++ b/examples/hello_pytorch/htcondor/apptainer/hello_pytorch_gpu_apptainer.sub
@@ -13,6 +13,8 @@ output = hello_pytorch_gpu_apptainer.out.txt
 executable = hello_pytorch_gpu_apptainer.sh
 arguments = $(Process)
 
++JobDurationCategory = "Medium"
+
 # transfer training data files and runtime source files to the compute node
 transfer_input_files = MNIST_data.tar.gz,../../src
 
@@ -23,10 +25,11 @@ should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 
 # We require a machine with a modern version of the CUDA driver
-requirements = (Target.CUDADriverVersion >= 12.0)
-requirements = (HasCHTCStaging == true)
+# requirements = (Target.CUDADriverVersion >= 12.0)
+# requirements = (HasCHTCStaging == true)
 # Don't use CentOS7 to ensure pty support
 requirements = (OpSysMajorVer > 7)
+gpus_minimum_capability = 7.5
 
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1
@@ -36,11 +39,16 @@ request_gpus = 1
 request_memory = 2GB
 request_disk = 6GB
 
+# required memory in MB (x000 is xGB)
+# gpus_minimum_memory = 6000
+
 # Opt in to using CHTC GPU Lab resources
 +WantGPULab = true
 # Specify short job type to run more GPUs in parallel
 # Can also request "medium" or "long"
 +GPUJobLength = "short"
+
++ProjectName="UWMadison_Feickert"
 
 # Tell HTCondor to run 1 instances of our job:
 queue 1

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
@@ -25,10 +25,17 @@ transfer_output_files = mnist_cnn.pt
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 
-# We require a machine with a modern version of the CUDA driver
-Requirements = (Target.CUDADriverVersion >= 12.0)
+# Require a machine with a modern version of the CUDA driver
+requirements = (GPUs_DriverVersion >= 12.0)
+
 # Don't use CentOS7 to ensure pty support
 requirements = (OpSysMajorVer > 7)
+
+# Optional: specify the GPU hardware architecture required
+# Check against the CUDA GPU Compute Capability for your software
+# e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
+# The listed 'sm_xy' values show the x.y gpu capability supported
+gpus_minimum_capability = 6.0
 
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
@@ -8,9 +8,9 @@ docker_pull_policy = missing
 container_image = docker://ghcr.io/uw-madison-dsi/pixi-docker-chtc:hello-pytorch-noble-cuda-12.9
 
 # set the log, error and output files
-log = hello_pytorch_gpu.log.txt
-error = hello_pytorch_gpu.err.txt
-output = hello_pytorch_gpu.out.txt
+log = hello_pytorch_gpu_$(Cluster)_$(Process).log.txt
+error = hello_pytorch_gpu_$(Cluster)_$(Process).err.txt
+output = hello_pytorch_gpu_$(Cluster)_$(Process).out.txt
 
 # set the executable to run
 executable = hello_pytorch_gpu.sh

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
@@ -35,7 +35,7 @@ requirements = (OpSysMajorVer > 7)
 # Check against the CUDA GPU Compute Capability for your software
 # e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
 # The listed 'sm_xy' values show the x.y gpu capability supported
-gpus_minimum_capability = 6.0
+gpus_minimum_capability = 5.0
 
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
@@ -31,12 +31,6 @@ requirements = (GPUs_DriverVersion >= 12.0)
 # Don't use CentOS7 to ensure pty support
 requirements = (OpSysMajorVer > 7)
 
-# Optional: specify the GPU hardware architecture required
-# Check against the CUDA GPU Compute Capability for your software
-# e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
-# The listed 'sm_xy' values show the x.y gpu capability supported
-gpus_minimum_capability = 5.0
-
 # We must request 1 CPU in addition to 1 GPU
 request_cpus = 1
 request_gpus = 1
@@ -44,6 +38,15 @@ request_gpus = 1
 # select some memory and disk space
 request_memory = 2GB
 request_disk = 2GB
+
+# Optional: specify the GPU hardware architecture required
+# Check against the CUDA GPU Compute Capability for your software
+# e.g. python -c "import torch; print(torch.cuda.get_arch_list())"
+# The listed 'sm_xy' values show the x.y gpu capability supported
+gpus_minimum_capability = 5.0
+
+# Optional: required GPU memory
+gpus_minimum_memory = 6GB
 
 # Opt in to using CHTC GPU Lab resources
 +WantGPULab = true

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
@@ -46,7 +46,7 @@ request_disk = 2GB
 gpus_minimum_capability = 5.0
 
 # Optional: required GPU memory
-gpus_minimum_memory = 4GB
+# gpus_minimum_memory = 4GB
 
 # Opt in to using CHTC GPU Lab resources
 +WantGPULab = true

--- a/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
+++ b/examples/hello_pytorch/htcondor/hello_pytorch_gpu.sub
@@ -46,7 +46,7 @@ request_disk = 2GB
 gpus_minimum_capability = 5.0
 
 # Optional: required GPU memory
-gpus_minimum_memory = 6GB
+gpus_minimum_memory = 4GB
 
 # Opt in to using CHTC GPU Lab resources
 +WantGPULab = true


### PR DESCRIPTION
Motivated by https://github.com/carpentries-incubator/reproducible-ml-workflows/issues/27, use syntax for the HTCondor submit description file that works on both CHTC and OSPool.

* Use `gpus_minimum_capability` to specify the minimum CUDA GPU Compute Capability required for the software.
   - c.f. https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#gpus_minimum_capability
   - c.f. https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities
   - c.f. https://modal.com/gpu-glossary/device-software/compute-capability#gpu-glossary
* Use `GPUs_DriverVersion` to specify the minimum version of the CUDA driver required for the software.
   - c.f. https://htcondor.readthedocs.io/en/latest/classad-attributes/machine-classad-attributes.html#%3Cname%3EDriverVersion
* Note that `gpus_minimum_memory` can optionally be specified.
   - c.f. https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#gpus_minimum_memory
* Use `$(Cluster)_$(Process)` file name suffix to be more standardized with best practices.
* Add links to HTCondor docs that deal with GPU specifics arguments and Modal's GPU Glossary website.

Example:

```console
$ pixi list --environment prod torch
Environment: prod
Package                     Version  Build                           Size       Kind   Source
libtorch                    2.7.1    cuda129_mkl_h9562ed8_304        836.3 MiB  conda  https://conda.anaconda.org/conda-forge/
pytorch                     2.7.1    cuda129_mkl_py313_h1e53aa0_304  28.1 MiB   conda  https://conda.anaconda.org/conda-forge/
pytorch-gpu                 2.7.1    cuda129_mkl_h43a4b0b_304        46.9 KiB   conda  https://conda.anaconda.org/conda-forge/
torchvision                 0.22.0   cuda_py313_h6be0d2c_2           3.2 MiB    conda  https://conda.anaconda.org/conda-forge/
torchvision-extra-decoders  0.0.2    py313hf1e760e_3                 62.9 KiB   conda  https://conda.anaconda.org/conda-forge/
$ pixi run --environment prod python -c "import torch; print(torch.cuda.get_arch_list())"
['sm_50', 'sm_60', 'sm_70', 'sm_75', 'sm_80', 'sm_86', 'sm_90', 'sm_100', 'sm_120', 'compute_120']
```

means that the version of PyTorch was compiled to support CUDA GPU compute capacity of v5.0+,  and so can request

```
gpus_minimum_capability = 5.0
```

in jobs.
