### PR TITLE
feat: Make the Dockerfile templated

### DIFF
--- a/examples/hello_pytorch/Dockerfile
+++ b/examples/hello_pytorch/Dockerfile
@@ -1,3 +1,4 @@
+# Declare build ARGS in global scope
 ARG CUDA_VERSION="12"
 ARG ENVIRONMENT="gpu"
 

--- a/examples/hello_pytorch/Dockerfile
+++ b/examples/hello_pytorch/Dockerfile
@@ -1,21 +1,30 @@
+ARG CUDA_VERSION="12"
+ARG ENVIRONMENT="gpu"
+
 FROM ghcr.io/prefix-dev/pixi:noble AS build
+
+# Redeclaring ARGS in a stage without a value inherits the global default
+ARG CUDA_VERSION
+ARG ENVIRONMENT
 
 WORKDIR /app
 COPY . .
-ENV CONDA_OVERRIDE_CUDA=12.0
-RUN pixi install --locked --environment prod
+ENV CONDA_OVERRIDE_CUDA=$CUDA_VERSION
+RUN pixi install --locked --environment $ENVIRONMENT
 RUN echo "#!/bin/bash" > /app/entrypoint.sh && \
-    pixi shell-hook --environment prod -s bash >> /app/entrypoint.sh && \
+    pixi shell-hook --environment $ENVIRONMENT -s bash >> /app/entrypoint.sh && \
     echo 'exec "$@"' >> /app/entrypoint.sh
 
-FROM ghcr.io/prefix-dev/pixi:noble AS production
+FROM ghcr.io/prefix-dev/pixi:noble AS final
+
+ARG ENVIRONMENT
 
 WORKDIR /app
-COPY --from=build /app/.pixi/envs/prod /app/.pixi/envs/prod
+COPY --from=build /app/.pixi/envs/$ENVIRONMENT /app/.pixi/envs/$ENVIRONMENT
 COPY --from=build /app/pixi.toml /app/pixi.toml
 COPY --from=build /app/pixi.lock /app/pixi.lock
-# Need the ignore files if you want to use `pixi run` commands
-COPY --from=build /app/.gitignore /app/.pixi/.gitignore
+# The ignore files are needed for 'pixi run' to work in the container
+COPY --from=build /app/.pixi/.gitignore /app/.pixi/.gitignore
 COPY --from=build /app/.pixi/.condapackageignore /app/.pixi/.condapackageignore
 COPY --from=build --chmod=0755 /app/entrypoint.sh /app/entrypoint.sh
 

--- a/examples/hello_pytorch/README.md
+++ b/examples/hello_pytorch/README.md
@@ -7,10 +7,10 @@ Train MNIST using PyTorch in a container.
 To ensure that the
 
 ```Dockerfile
-RUN pixi install --locked --environment prod
+RUN pixi install --locked --environment gpu
 ```
 
-command will succeed the `pixi.lock` needs to know about the existence of the `prod` environment and be current with it, so run
+command will succeed the `pixi.lock` needs to know about the existence of the `gpu` environment and be current with it, so run
 
 ```
 pixi lock

--- a/examples/hello_pytorch/apptainer.def
+++ b/examples/hello_pytorch/apptainer.def
@@ -12,9 +12,9 @@ Stage: build
 export CONDA_OVERRIDE_CUDA=12
 cd /app/
 pixi info
-pixi install --locked --environment prod
+pixi install --locked --environment gpu
 echo "#!/bin/bash" > /app/entrypoint.sh && \
-pixi shell-hook --environment prod -s bash >> /app/entrypoint.sh && \
+pixi shell-hook --environment gpu -s bash >> /app/entrypoint.sh && \
 echo 'exec "$@"' >> /app/entrypoint.sh
 
 
@@ -23,7 +23,7 @@ From: ghcr.io/prefix-dev/pixi:noble
 Stage: final
 
 %files from build
-/app/.pixi/envs/prod /app/.pixi/envs/prod
+/app/.pixi/envs/gpu /app/.pixi/envs/gpu
 /app/pixi.toml /app/pixi.toml
 /app/pixi.lock /app/pixi.lock
 /app/.gitignore /app/.gitignore

--- a/examples/hello_pytorch/htcondor/pixi-pack/README.md
+++ b/examples/hello_pytorch/htcondor/pixi-pack/README.md
@@ -12,7 +12,7 @@ This example contains the files:
 As the Pixi environment is fully specified through the `pixi.lock` lock file, it is possible to download all of the environment conda packages and export them into an archive with [`pixi-pack`](https://pixi.sh/latest/deployment/pixi_pack/).
 
 ```
-pixi pack --environment prod --platform linux-64 pixi.toml
+pixi pack --environment gpu --platform linux-64 pixi.toml
 ```
 
 This will create an `environment.tar` archive with all of the packages required to create the Pixi environment.
@@ -21,7 +21,7 @@ One can use `pixi-pack unpack` to unpack the archive and create the environment 
 In the event that the target machine does not, and can't, have `pixi-pack` installed, `pixi-pack` can create a self-extracting binary `environment.sh` with
 
 ```
-pixi pack --environment prod --platform linux-64 --create-executable pixi.toml
+pixi pack --environment gpu --platform linux-64 --create-executable pixi.toml
 ```
 
 which when executed on a target machine of the same platform extracts the environment directory tree and an activation script from the archive

--- a/examples/hello_pytorch/pixi.lock
+++ b/examples/hello_pytorch/pixi.lock
@@ -124,29 +124,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-  pack:
-    channels:
-    - url: https://conda.anaconda.org/conda-forge/
-    packages:
-      linux-64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixi-pack-0.7.2-h2d22210_0.conda
-      osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.2-he92f556_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixi-pack-0.7.2-h2b2570c_0.conda
-      win-64:
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pixi-pack-0.7.2-h18a1a76_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
-  prod:
+  gpu:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     packages:
@@ -270,6 +248,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+  pack:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixi-pack-0.7.2-h2d22210_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.2-he92f556_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixi-pack-0.7.2-h2b2570c_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixi-pack-0.7.2-h18a1a76_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726

--- a/examples/hello_pytorch/pixi.toml
+++ b/examples/hello_pytorch/pixi.toml
@@ -47,16 +47,16 @@ torchvision = ">=0.22.0,<0.23"
 pixi-pack = ">=0.7.2,<0.8"
 
 [feature.pack.tasks.pack]
-description = "Pack the production environment into a pixi-pack archive"
+description = "Pack the gpu environment into a pixi-pack archive"
 cmd = """
-pixi pack --environment prod --platform linux-64 pixi.toml
+pixi pack --environment gpu --platform linux-64 pixi.toml
 """
 outputs = ["environment.tar"]
 
 [feature.pack.tasks.pack-executable]
-description = "Pack the production environment into self-extracting executable"
+description = "Pack the gpu environment into self-extracting executable"
 cmd = """
-pixi pack --environment prod --platform linux-64 --create-executable pixi.toml
+pixi pack --environment gpu --platform linux-64 --create-executable pixi.toml
 """
 outputs = ["environment.sh"]
 
@@ -75,5 +75,5 @@ cp environment.sh environment-"$(openssl sha256 -r environment.sh | cut -b -8)".
 """
 
 [environments]
-prod = { features = [], solve-group = "prod" }
+gpu = { features = [], solve-group = "gpu" }
 pack = { features = ["pack"], no-default-feature = true }


### PR DESCRIPTION
* Use Dockerfile `ARG` variables to make the `CONDA_OVERRIDE_CUDA` and environment names variables that can be set at the command line. Use global and local scope to only declare ARG values once. This results in the Dockerfile now being a template.
   - c.f. https://docs.docker.com/reference/dockerfile/#arg 
   - c.f. https://docs.docker.com/build/building/variables/#scoping
* Rename 'prod' environment to 'gpu' for clarity.