### PR TITLE
chore: Change MNIST dataset download path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 
 # Apptainer
 *.sif
+
+# data dirs
+data/

--- a/examples/hello_pytorch/pixi.toml
+++ b/examples/hello_pytorch/pixi.toml
@@ -20,7 +20,7 @@ python ./src/torch_detect_GPU.py
 [tasks.train-mnist]
 description = "Train a simple PyTorch neural net classifier on the MNIST dataset"
 cmd = """
-python ./src/torch_MNIST.py
+python ./src/torch_MNIST.py --save-model
 """
 
 [tasks.download-mnist]

--- a/examples/hello_pytorch/pixi.toml
+++ b/examples/hello_pytorch/pixi.toml
@@ -29,7 +29,7 @@ cmd = """
 python -c "\
 from torchvision import datasets, transforms; \
 transform = transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]); \
-dataset1 = datasets.MNIST('../data', train=True, download=True, transform=transform)"
+dataset1 = datasets.MNIST('data', train=True, download=True, transform=transform)"
 """
 
 # Required for picking up the correct versions of pytorch


### PR DESCRIPTION
* Have `download-mnist` Pixi task download the `data/` directory to the current directory.
   - Amends PR https://github.com/UW-Madison-DSI/pixi-docker-chtc/pull/20.
* In `train-mnist` task default to saving the model.
* Ignore the data directory.